### PR TITLE
[API] broadcast orchestrator progress via WebSocket

### DIFF
--- a/apps/api/blackletter_api/tests/integration/test_websocket_progress.py
+++ b/apps/api/blackletter_api/tests/integration/test_websocket_progress.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+from blackletter_api.orchestrator.state import orchestrator, AnalysisState
+
+client = TestClient(app)
+
+
+def test_websocket_progress_broadcast_ordered_messages():
+    analysis_id = orchestrator.intake("contract.pdf")
+
+    with client.websocket_connect(f"/ws/analysis/{analysis_id}") as ws1, \
+         client.websocket_connect(f"/ws/analysis/{analysis_id}") as ws2:
+        assert ws1.receive_json()["type"] == "connection"
+        assert ws2.receive_json()["type"] == "connection"
+
+        states = [
+            AnalysisState.QUEUED,
+            AnalysisState.EXTRACTING,
+            AnalysisState.DETECTING,
+            AnalysisState.REPORTING,
+            AnalysisState.DONE,
+        ]
+
+        for state in states:
+            orchestrator.advance(analysis_id, state)
+
+        received1 = [ws1.receive_json()["state"] for _ in states]
+        received2 = [ws2.receive_json()["state"] for _ in states]
+
+        def dedupe(seq: list[str]) -> list[str]:
+            out: list[str] = []
+            for item in seq:
+                if not out or out[-1] != item:
+                    out.append(item)
+            return out
+
+        assert dedupe(received1) == [s.value for s in states]
+        assert dedupe(received2) == [s.value for s in states]


### PR DESCRIPTION
## What changed
- expose orchestrator state transitions through a simple pub/sub and notify WebSocket clients
- send progress updates (queued → extracting → detecting → reporting → done) to all connected clients
- add integration test for progress broadcast over WebSocket

## Why (risk, user impact)
- enables clients to track analysis progress in real time, improving transparency
- low risk: in-memory pub/sub and WebSocket broadcast with minimal surface

## Tests & Evidence
- `SECRET_KEY=test pytest -q apps/api/blackletter_api/tests/integration/test_websocket_progress.py` *(fails: KeyboardInterrupt)*

## Migration note (alembic)
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b66da29330832f8de54a85fc3aaf15