### PR TITLE
docs: rename Non Functional heading

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -36,7 +36,7 @@ The functional requirements (FRs) detail the specific features and behaviors of 
 * **FR13:** The system must allow users to see a "diff" or a redline of a contract, showing proposed changes to mitigate identified risks.
 * **FR14:** The system must offer a subscription-based model for access to its services.
 
-### Non Functional
+### Non-Functional Requirements
 The non-functional requirements (NFRs) describe the qualities of the system, which are crucial for user experience and trust.
 
 * **NFR1: Security:** All data, including uploaded documents and client information, must be encrypted both in transit and at rest.


### PR DESCRIPTION
## Summary
- rename "Non Functional" section heading to "Non-Functional Requirements"

## Testing
- `pytest apps/api/blackletter_api/tests -q` *(fails: argon2 backend missing, multiple other failures)*
- `pytest apps/api/blackletter_api/tests/test_auth_router.py::test_register_user_success -q` *(fails: MissingBackendError: argon2 no backends)*

------
https://chatgpt.com/codex/tasks/task_e_68ba129828b8832f81be8c8db21cc922