### PR TITLE
feat: add clipboard fallback and tests

### DIFF
--- a/blackletter/blackletter-upstream/frontend/components/EvidenceDrawer.tsx
+++ b/blackletter/blackletter-upstream/frontend/components/EvidenceDrawer.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { Finding } from '@/lib/types';
 import { highlightAnchors } from '@/lib/anchors';
+import { copyToClipboard } from '@/lib/utils';
 
 interface EvidenceDrawerProps {
   isOpen: boolean;
@@ -37,8 +38,8 @@ export default function EvidenceDrawer({ isOpen, onClose, finding }: EvidenceDra
   // Highlight anchors in the evidence text
   const highlightedEvidence = highlightAnchors(finding.evidence, finding.anchors);
 
-  const handleCopyToClipboard = () => {
-    navigator.clipboard.writeText(finding.evidence);
+  const handleCopyToClipboard = async () => {
+    await copyToClipboard(highlightedEvidence);
     // Could add a toast notification here
   };
 

--- a/blackletter/blackletter-upstream/frontend/components/__tests__/EvidenceDrawer.test.tsx
+++ b/blackletter/blackletter-upstream/frontend/components/__tests__/EvidenceDrawer.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import EvidenceDrawer from '../EvidenceDrawer';
+
+describe('EvidenceDrawer copy button', () => {
+  beforeEach(() => {
+    (navigator as any).clipboard = {
+      writeText: jest.fn().mockResolvedValue(undefined),
+    };
+    (navigator as any).permissions = {
+      query: jest.fn().mockResolvedValue({ state: 'granted' }),
+    };
+  });
+
+  it('copies sanitized evidence text', async () => {
+    const finding = {
+      id: '1',
+      detector: 'detector',
+      verdict: 'pass',
+      rationale: 'because',
+      evidence: 'This is <b>bold</b> evidence',
+      anchors: [],
+      reviewed: false,
+    };
+
+    render(
+      <EvidenceDrawer isOpen={true} onClose={() => {}} finding={finding} />
+    );
+
+    const button = screen.getByText('Copy to Clipboard');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('This is bold evidence');
+    });
+  });
+});

--- a/blackletter/blackletter-upstream/frontend/lib/__tests__/copyToClipboard.test.ts
+++ b/blackletter/blackletter-upstream/frontend/lib/__tests__/copyToClipboard.test.ts
@@ -1,0 +1,28 @@
+import { copyToClipboard } from '../utils';
+
+describe('copyToClipboard', () => {
+  beforeEach(() => {
+    (navigator as any).clipboard = {
+      writeText: jest.fn().mockResolvedValue(undefined),
+    };
+    (navigator as any).permissions = {
+      query: jest.fn().mockResolvedValue({ state: 'granted' }),
+    };
+  });
+
+  it('copies sanitized text using Clipboard API', async () => {
+    const html = '<p>Hello <b>World</b></p>';
+    const result = await copyToClipboard(html);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Hello World');
+    expect(result).toBe(true);
+  });
+
+  it('falls back to execCommand when Clipboard API fails', async () => {
+    (navigator as any).clipboard.writeText.mockRejectedValue(new Error('denied'));
+    document.execCommand = jest.fn().mockReturnValue(true);
+
+    const result = await copyToClipboard('Fallback test');
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize clipboard text and add permission-checked fallback when copying
- use centralized copy helper in EvidenceDrawer
- add unit tests for clipboard copy behavior

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba16a5f9a4832f83929488fe10049f