### PR TITLE
fix(web): ensure PageFinding objects carry ids

### DIFF
--- a/apps/web/src/app/analyses/[jobId]/AnalysesClient.tsx
+++ b/apps/web/src/app/analyses/[jobId]/AnalysesClient.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { PageFinding } from '@/lib/types';
-import { toFinding } from '@/lib/types';
+import { toFinding, ensurePageFindingIds } from '@/lib/types';
 import FindingsTable from '@/components/FindingsTable';
 import EvidenceDrawer from '@/components/EvidenceDrawer';
 import { mockAnalysis } from '@/lib/mockReports';
@@ -11,6 +11,10 @@ export default function AnalysesClient({ jobId }: { jobId: string }) {
   const [selected, setSelected] = useState<PageFinding | null>(null);
 
   const analysis = mockAnalysis; // TODO: fetch by jobId
+  const findings = useMemo(
+    () => ensurePageFindingIds(analysis.findings as PageFinding[]),
+    [analysis.findings],
+  );
 
   const onRowClick = (f: PageFinding) => setSelected(f);
   const onClose = () => setSelected(null);
@@ -20,7 +24,7 @@ export default function AnalysesClient({ jobId }: { jobId: string }) {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-4">Analysis Findings for Job ID: {jobId}</h1>
-      <FindingsTable findings={analysis.findings as PageFinding[]} onRowClick={onRowClick} />
+      <FindingsTable findings={findings} onRowClick={onRowClick} />
       <EvidenceDrawer isOpen={!!selected} onClose={onClose} finding={selected ? toFinding(selected) : null} />
     </div>
   );

--- a/apps/web/src/components/FindingsTable.test.tsx
+++ b/apps/web/src/components/FindingsTable.test.tsx
@@ -3,22 +3,28 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import FindingsTable from './FindingsTable';
 import type { PageFinding } from '@/lib/types';
+import { ensurePageFindingIds } from '@/lib/types';
 import { vi } from 'vitest';
 
 describe('FindingsTable', () => {
-  const findings: PageFinding[] = [
-    {
-      id: '1',
-      rule_id: 'art28-3-a',
-      snippet: 'sample snippet',
-      anchors: [],
-    },
+  const baseFindings: PageFinding[] = [
+    { id: '1', rule_id: 'art28-3-a', snippet: 'sample snippet', anchors: [] },
+    { rule_id: 'art28-3-b', snippet: 'second snippet', anchors: [] },
   ];
 
-    it('renders findings and triggers callback on row click', () => {
-      const onRowClick = vi.fn();
-      render(<FindingsTable findings={findings} onRowClick={onRowClick} />);
-      fireEvent.click(screen.getByText('art28-3-a'));
-      expect(onRowClick).toHaveBeenCalled();
-    });
+  it('renders findings and triggers callback on row click', () => {
+    const findings = ensurePageFindingIds(baseFindings);
+    const onRowClick = vi.fn();
+    render(<FindingsTable findings={findings} onRowClick={onRowClick} />);
+    fireEvent.click(screen.getByText('art28-3-a'));
+    fireEvent.click(screen.getByText('art28-3-b'));
+    expect(onRowClick).toHaveBeenNthCalledWith(1, findings[0]);
+    expect(onRowClick).toHaveBeenNthCalledWith(2, findings[1]);
   });
+
+  it('ensures ids are generated when missing', () => {
+    const findings = ensurePageFindingIds(baseFindings);
+    expect(findings[0].id).toBe('1');
+    expect(findings[1].id).toBeDefined();
+  });
+});

--- a/apps/web/src/components/FindingsTable.tsx
+++ b/apps/web/src/components/FindingsTable.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { PageFinding } from '@/lib/types';
 
 type Props = {
-  findings: PageFinding[];
+  findings: Array<PageFinding & { id: string }>;
   onRowClick?: (f: PageFinding) => void;
 };
 
@@ -20,7 +20,7 @@ export default function FindingsTable({ findings, onRowClick }: Props) {
         <tbody>
           {findings.map((f) => (
             <tr
-              key={f.id ?? `${f.rule_id}-${f.snippet.slice(0, 16)}`}
+              key={f.id}
               className="cursor-pointer hover:bg-muted/50"
               onClick={() => onRowClick?.(f)}
             >

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -25,12 +25,18 @@ export type Finding = {
 
 // Legacy page finding used by tables/pages
 export type PageFinding = {
-  id: string;
+  id?: string;
   rule_id: string;
   snippet: string;
   evidence?: Array<{ page: number; start: number; end: number }>;
   anchors?: string[];
 };
+
+export function ensurePageFindingIds(
+  findings: PageFinding[],
+): Array<PageFinding & { id: string }> {
+  return findings.map((f) => ({ ...f, id: f.id ?? crypto.randomUUID() }));
+}
 
 // Adapter: PageFinding -> Finding (for Drawer)
 export function toFinding(f: PageFinding): Finding {


### PR DESCRIPTION
## Summary
- allow `PageFinding` to have optional ids and add helper to assign ids
- generate ids when loading findings and drop key fallback in table
- test rendering with and without preset ids

## Testing
- `pnpm --filter web typecheck`
- `pnpm --filter web exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ba1285b7e4832fba1cc27779748b94