### PR TITLE
feat(web): add accessible diff viewer with ARIA cues

### DIFF
--- a/apps/web/src/components/DiffView.test.tsx
+++ b/apps/web/src/components/DiffView.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DiffView from './DiffView';
+
+describe('DiffView accessibility', () => {
+  it('shows icons and aria labels for insertions and deletions', () => {
+    render(<DiffView oldText="a b" newText="a c" />);
+    const insertion = screen.getByLabelText(/^Insertion:/);
+    const deletion = screen.getByLabelText(/^Deletion:/);
+    expect(insertion.querySelector('svg')).not.toBeNull();
+    expect(deletion.querySelector('svg')).not.toBeNull();
+  });
+
+  it('announces diff region updates via aria-live', () => {
+    render(<DiffView oldText="foo" newText="bar" />);
+    const region = screen.getByRole('region', { name: /diff results/i });
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/apps/web/src/components/DiffView.tsx
+++ b/apps/web/src/components/DiffView.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Plus, Minus } from 'lucide-react';
+
+interface DiffPart {
+  value: string;
+  added?: boolean;
+  removed?: boolean;
+}
+
+function computeDiff(oldText: string, newText: string): DiffPart[] {
+  const oldWords = oldText.split(/\s+/);
+  const newWords = newText.split(/\s+/);
+  const result: DiffPart[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < oldWords.length || j < newWords.length) {
+    const oldWord = oldWords[i];
+    const newWord = newWords[j];
+    if (oldWord === newWord) {
+      result.push({ value: `${newWord}${j < newWords.length - 1 ? ' ' : ''}` });
+      i += 1;
+      j += 1;
+    } else {
+      if (newWord !== undefined) {
+        result.push({ value: `${newWord} `, added: true });
+        j += 1;
+      }
+      if (oldWord !== undefined) {
+        result.push({ value: `${oldWord} `, removed: true });
+        i += 1;
+      }
+    }
+  }
+  return result;
+}
+
+interface DiffViewProps {
+  oldText: string;
+  newText: string;
+}
+
+export default function DiffView({ oldText, newText }: DiffViewProps) {
+  const parts = computeDiff(oldText, newText);
+  return (
+    <div role="region" aria-live="polite" aria-label="Diff results">
+      {parts.map((part, idx) => {
+        if (part.added) {
+          return (
+            <span
+              key={idx}
+              className="diff-added inline-flex items-center"
+              aria-label={`Insertion: ${part.value}`}
+            >
+              <Plus className="mr-1 h-3 w-3" aria-hidden="true" />
+              <span aria-hidden="true">{part.value}</span>
+            </span>
+          );
+        }
+        if (part.removed) {
+          return (
+            <span
+              key={idx}
+              className="diff-removed inline-flex items-center line-through"
+              aria-label={`Deletion: ${part.value}`}
+            >
+              <Minus className="mr-1 h-3 w-3" aria-hidden="true" />
+              <span aria-hidden="true">{part.value}</span>
+            </span>
+          );
+        }
+        return (
+          <span key={idx} aria-hidden="true">{part.value}</span>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add DiffView component rendering insertions and deletions with icons and ARIA labels
- include acceptance tests ensuring non-colour cues and screen reader announcements

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ba169d0a1c832fbe18a796f5f479c5