### PR TITLE
Add axe-based accessibility checks for web components

### DIFF
--- a/apps/web/src/components/EvidenceDrawer.test.tsx
+++ b/apps/web/src/components/EvidenceDrawer.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import userEvent from '@testing-library/user-event';
+import axe from 'axe-core';
 import EvidenceDrawer from './EvidenceDrawer';
 import type { Finding } from '@/lib/types';
 
@@ -51,6 +53,36 @@ describe('EvidenceDrawer', () => {
       <EvidenceDrawer isOpen onClose={() => {}} finding={null} />
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('has semantic headings and lists with no a11y violations', async () => {
+    render(<EvidenceDrawer isOpen onClose={() => {}} finding={baseFinding} onOpenPage={() => {}} />);
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Evidence' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    const results = await axe.run(document.body);
+    expect(results.violations.length).toBeLessThanOrEqual(0);
+  });
+
+  it('supports keyboard navigation for citations and close button', async () => {
+    render(<EvidenceDrawer isOpen onClose={() => {}} finding={baseFinding} onOpenPage={() => {}} />);
+    const citation = screen.getByTestId('citation-link');
+    const closeButton = screen.getByTestId('close-button');
+    await userEvent.tab();
+    expect(citation).toHaveFocus();
+    await userEvent.tab();
+    expect(closeButton).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(citation).toHaveFocus();
+  });
+
+  it('meets color contrast guidelines for highlights', async () => {
+    render(<EvidenceDrawer isOpen onClose={() => {}} finding={baseFinding} onOpenPage={() => {}} />);
+    const results = await axe.run(document.body, {
+      runOnly: { type: 'rule', values: ['color-contrast'] },
+    });
+    expect(results.violations.length).toBeLessThanOrEqual(0);
   });
 });
 

--- a/apps/web/src/components/EvidenceDrawer.tsx
+++ b/apps/web/src/components/EvidenceDrawer.tsx
@@ -64,9 +64,9 @@ export default function EvidenceDrawer({ isOpen, onClose, finding, onOpenPage }:
               )}
 
               <div className="mt-4">
-                <h4 className="text-sm font-medium">Evidence</h4>
+                <h3 className="text-sm font-medium">Evidence</h3>
                 <div
-                  className="mt-2 max-h-64 overflow-y-auto border p-2 text-sm" 
+                  className="mt-2 max-h-64 overflow-y-auto border p-2 text-sm"
                   data-testid="evidence-panel"
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{ __html: highlighted }}
@@ -75,7 +75,7 @@ export default function EvidenceDrawer({ isOpen, onClose, finding, onOpenPage }:
 
               {finding.citations && finding.citations.length > 0 && (
                 <div className="mt-4" data-testid="citations">
-                  <h4 className="text-sm font-medium">Citations</h4>
+                  <h3 className="text-sm font-medium">Citations</h3>
                   <ul className="mt-2 space-y-2">
                     {finding.citations.map((c, i) => (
                       <li key={i} className="flex items-start justify-between gap-2 text-sm" data-testid="citation-item">

--- a/apps/web/src/components/FindingsDrawer.test.tsx
+++ b/apps/web/src/components/FindingsDrawer.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axe from 'axe-core';
 import FindingsDrawer from './FindingsDrawer';
 import { vi } from 'vitest';
 
@@ -25,6 +27,30 @@ describe('FindingsDrawer', () => {
     render(<FindingsDrawer open onClose={onClose} finding={finding} />);
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('has semantic structure and no a11y violations', async () => {
+    render(<FindingsDrawer open onClose={() => {}} finding={finding} />);
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Finding Details/ })
+    ).toBeInTheDocument();
+    const results = await axe.run(screen.getByTestId('findings-drawer'), {
+      rules: { 'color-contrast': { enabled: false } },
+    });
+    expect(results.violations.length).toBeLessThanOrEqual(0);
+  });
+
+  it('traps focus within the drawer', async () => {
+    render(<FindingsDrawer open onClose={() => {}} finding={finding} />);
+    const drawer = screen.getByTestId('findings-drawer');
+    const closeButton = screen.getByTestId('close-button');
+    await waitFor(() => expect(drawer).toHaveFocus());
+    await userEvent.tab();
+    expect(closeButton).toHaveFocus();
+    await userEvent.tab();
+    expect(closeButton).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(closeButton).toHaveFocus();
   });
 });
 

--- a/apps/web/src/components/FindingsDrawer.tsx
+++ b/apps/web/src/components/FindingsDrawer.tsx
@@ -55,6 +55,7 @@ export default function FindingsDrawer({ open, onClose, finding }: FindingsDrawe
       <div
         ref={drawerRef}
         tabIndex={-1}
+        data-testid="findings-drawer"
         className="absolute right-0 top-0 h-full w-80 bg-white p-6 shadow-lg space-y-4"
       >
         <div>
@@ -66,7 +67,7 @@ export default function FindingsDrawer({ open, onClose, finding }: FindingsDrawe
           )}
         </div>
         <div className="flex justify-end">
-          <button onClick={onClose} className="text-sm underline">Close</button>
+          <button onClick={onClose} className="text-sm underline" data-testid="close-button">Close</button>
         </div>
       </div>
     </div>

--- a/apps/web/src/lib/anchors.test.ts
+++ b/apps/web/src/lib/anchors.test.ts
@@ -10,6 +10,7 @@ describe('highlightAnchors', () => {
     const html = highlightAnchors(sample, anchors);
     expect(html).toContain('<mark');
     expect(html).toContain('quick');
+    expect(html).toContain('style="background-color:#fef08a;color:#000"');
   });
 
   it('highlights multiple anchors', () => {

--- a/apps/web/src/lib/anchors.ts
+++ b/apps/web/src/lib/anchors.ts
@@ -20,11 +20,11 @@ export function highlightAnchors(evidence: string, anchors: Anchor[]): string {
     if (start < lastIndex || start >= evidence.length) return; // skip overlaps/out of bounds
     result += evidence.slice(lastIndex, start);
     const segment = evidence.slice(start, end);
-    result += `<mark data-anchorkey="a${i}" tabindex="0">${segment}</mark>`;
+    result += `<mark style="background-color:#fef08a;color:#000" data-anchorkey="a${i}" tabindex="0">${segment}</mark>`;
     lastIndex = end;
   });
   result += evidence.slice(lastIndex);
 
-  return DOMPurify.sanitize(result, { ADD_ATTR: ['data-anchorkey', 'tabindex'] });
+  return DOMPurify.sanitize(result, { ADD_ATTR: ['data-anchorkey', 'tabindex', 'style'] });
 }
 

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom';
 
+// Stub canvas context for axe-core color contrast checks
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: () => ({ getImageData: () => ({ data: [] }) }),
+});
+
 // Suppress console errors during tests to avoid noise from intentional error testing
 const originalError = console.error;
 beforeAll(() => {


### PR DESCRIPTION
## Summary
- ensure evidence anchors render with high-contrast highlight
- add axe-core tests for semantic headings, keyboard navigation, and color contrast
- verify focus trap in findings drawer and guard against a11y violations

## Testing
- `pnpm --filter web test --run`


------
https://chatgpt.com/codex/tasks/task_e_68ba24bb2a58832f86862cba613c3e91