### PR TITLE
fix(web): add static params and cache Playwright browsers

### DIFF
--- a/.github/workflows/web-swa.yml
+++ b/.github/workflows/web-swa.yml
@@ -9,6 +9,15 @@ jobs:
         with: { node-version: '18.x', cache: 'pnpm', cache-dependency-path: 'pnpm-lock.yaml' }
       - run: npm i -g pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright/
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - run: pnpm --filter ./apps/web run e2e:install
+      - run: pnpm --filter ./apps/web run test:e2e
       - run: pnpm --filter ./apps/web build
       - uses: Azure/static-web-apps-deploy@v2
         with:

--- a/apps/web/src/app/analyses/[jobId]/AnalysisDetailClient.tsx
+++ b/apps/web/src/app/analyses/[jobId]/AnalysisDetailClient.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useAnalysis } from '@/hooks/useAnalysis';
+import { useFindings } from '@/hooks/useFindings';
+import SkeletonLoader from '@/components/findings/SkeletonLoader';
+import FindingsTable from '@/components/findings/FindingsTable';
+
+interface AnalysisDetailClientProps {
+  jobId: string;
+}
+
+export default function AnalysisDetailClient({ jobId }: AnalysisDetailClientProps) {
+  const { data: analysis, loading: loadingAnalysis, error: analysisError } = useAnalysis(jobId);
+  const { data: findings, loading: loadingFindings, error: findingsError } = useFindings(jobId);
+
+  if (!jobId) {
+    return <p className="text-sm text-red-600">Invalid analysis id</p>;
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Analysis {jobId}</h1>
+        <div className="text-sm text-gray-600">State: {analysis?.state ?? '…'}</div>
+      </header>
+
+      {(loadingAnalysis || (!analysis && !analysisError)) && <SkeletonLoader />}
+      {analysisError && <p className="text-sm text-red-600">{analysisError}</p>}
+
+      {findingsError && <p className="text-sm text-red-600">{findingsError}</p>}
+      {findings && findings.length > 0 && <FindingsTable findings={findings} />}
+      {loadingFindings && <SkeletonLoader />}
+      {findings && findings.length === 0 && (
+        <p className="text-sm text-gray-600">No findings available for this analysis.</p>
+      )}
+    </div>
+  );
+}
+

--- a/apps/web/src/app/analyses/[jobId]/page.tsx
+++ b/apps/web/src/app/analyses/[jobId]/page.tsx
@@ -1,36 +1,17 @@
-"use client";
-import { useParams } from 'next/navigation';
-import { useAnalysis } from '@/hooks/useAnalysis';
-import { useFindings } from '@/hooks/useFindings';
-import SkeletonLoader from '@/components/findings/SkeletonLoader';
-import FindingsTable from '@/components/findings/FindingsTable';
+import AnalysisDetailClient from './AnalysisDetailClient';
 
-export default function AnalysisDetailPage() {
-  const params = useParams();
-  const analysisId = String((params as any)?.jobId ?? '');
-  const { data: analysis, loading: loadingAnalysis, error: analysisError } = useAnalysis(analysisId);
-  const { data: findings, loading: loadingFindings, error: findingsError } = useFindings(analysisId);
-
-  if (!analysisId) {
-    return <p className="text-sm text-red-600">Invalid analysis id</p>;
-  }
-
-  return (
-    <div className="max-w-5xl mx-auto p-6 space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Analysis {analysisId}</h1>
-        <div className="text-sm text-gray-600">State: {analysis?.state ?? '…'}</div>
-      </header>
-
-      {(loadingAnalysis || (!analysis && !analysisError)) && <SkeletonLoader />}
-      {analysisError && <p className="text-sm text-red-600">{analysisError}</p>}
-
-      {findingsError && <p className="text-sm text-red-600">{findingsError}</p>}
-      {findings && findings.length > 0 && <FindingsTable findings={findings} />}
-      {loadingFindings && <SkeletonLoader />}
-      {findings && findings.length === 0 && (
-        <p className="text-sm text-gray-600">No findings available for this analysis.</p>
-      )}
-    </div>
-  );
+interface AnalysisDetailPageProps {
+  params: { jobId: string };
 }
+
+export default function AnalysisDetailPage({ params }: AnalysisDetailPageProps) {
+  return <AnalysisDetailClient jobId={String(params.jobId)} />;
+}
+
+export async function generateStaticParams() {
+  // In a real production build, you might fetch real job IDs here.
+  // Providing a placeholder allows the static export build to succeed
+  // while enabling dynamic, on-demand rendering during tests.
+  return [{ jobId: 'placeholder' }];
+}
+


### PR DESCRIPTION
## Summary
- add placeholder `generateStaticParams` for analysis detail route
- cache Playwright browsers in web SWA workflow
- extract client analysis detail component

## Testing
- `CI=1 pnpm --filter web run test`
- `pnpm --filter web run build` *(fails: Page with `dynamic = "force-dynamic"` couldn't be exported)*
- `pnpm --filter web run e2e:install` *(fails: Download failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2410ff24832fa8cf5a6303d63812