### PR TITLE
feat: add backend option for job enqueue

### DIFF
--- a/apps/api/blackletter_api/tests/unit/test_enqueue_job.py
+++ b/apps/api/blackletter_api/tests/unit/test_enqueue_job.py
@@ -9,9 +9,8 @@ def test_enqueue_job_sync(monkeypatch):
     def fake_process(job_id, analysis_id, filename, size):  # noqa: ANN001
         called["args"] = (job_id, analysis_id, filename, size)
 
-    monkeypatch.setenv("JOB_SYNC", "1")
     monkeypatch.setattr(tasks, "process_job", fake_process)
-    tasks.enqueue_job("jid", "aid", "file.pdf", 10)
+    tasks.enqueue_job("jid", "aid", "file.pdf", 10, backend="sync")
     assert called["args"] == ("jid", "aid", "file.pdf", 10)
 
 
@@ -21,8 +20,7 @@ def test_enqueue_job_async(monkeypatch):
     def fake_delay(job_id, analysis_id, filename, size):  # noqa: ANN001
         called["args"] = (job_id, analysis_id, filename, size)
 
-    monkeypatch.delenv("JOB_SYNC", raising=False)
     monkeypatch.setattr(tasks.process_job, "delay", fake_delay)
-    tasks.enqueue_job("jid", "aid", "file.pdf", 5)
+    tasks.enqueue_job("jid", "aid", "file.pdf", 5, backend="celery")
     assert called["args"] == ("jid", "aid", "file.pdf", 5)
 


### PR DESCRIPTION
## Summary
- allow enqueue_job to accept backend argument for explicit dispatch
- update worker tests to use new backend parameter

## Testing
- `pytest apps/api/blackletter_api/tests/unit/test_enqueue_job.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2ee24600832f8b6453f4ccdb67a7