### PR TITLE
feat: add demo CTA

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -89,8 +89,8 @@ export default function LandingPage() {
             <Link href="/new" className="btn-primary" aria-label="Start free trial of GDPR Checker">
               Start Free 14-Day Trial
             </Link>
-            <Link href="/reports" className="btn-secondary" aria-label="View interactive demo dashboard">
-              Watch Interactive Demo
+            <Link href="/dashboard" className="btn-secondary" aria-label="Try the Blackletter demo dashboard">
+              Try the Demo
             </Link>
           </div>
           <div className="hero-micro fade-in stagger-4">

--- a/docs/stories/0.2-landing-page-minimal.md
+++ b/docs/stories/0.2-landing-page-minimal.md
@@ -1,18 +1,18 @@
 **ID**: 0.2
 **Epic**: 0  Landing (Marketing)
 **Status**: **Approved**
-**Goal**: Deliver a minimal, accessible landing page with a clear hero and a �?oTry the Demo�?? CTA linking to `/dashboard` (demo mode), independent of backend.
+**Goal**: Deliver a minimal, accessible landing page with a clear hero and CTAs: "Start Free 14-Day Trial" linking to `/new` and "Try the Demo" linking to `/dashboard` (demo mode), independent of backend.
 
 ## Context
 
-- Route: `/landing` (optional default redirect from `/`).
-- Independent of `NEXT_PUBLIC_USE_MOCKS` (static content), but CTA targets the demo flow.
+- Route: `/`.
+- Independent of `NEXT_PUBLIC_USE_MOCKS` (static content), but CTAs target the trial and demo flows.
 - Deployable to Vercel immediately.
 
 ## Acceptance Criteria
 
-1. Responsive hero section with a concise value proposition and sub�?'copy.
-2. Primary CTA �?oTry the Demo�?? links to `/dashboard`; secondary �?oRead the PRD�?? links to docs (optional).
+1. Responsive hero section with a concise value proposition and sub copy.
+2. Primary CTA "Start Free 14-Day Trial" links to `/new`; secondary CTA "Try the Demo" links to `/dashboard`.
 3. WCAG AA: sufficient contrast, keyboard navigable, visible focus, semantic headings.
 4. Metadata: `<title>`, `<meta name="description">`, Open Graph tags, favicon.
 5. No backend assumptions; page loads fast and statically.
@@ -29,7 +29,7 @@ tasks: []
 
 **proposed_tasks**
 
-- [x] Add `/landing` page with hero, sub-copy, and CTA to `/dashboard`.
+- [x] Add landing page with hero, sub-copy, and CTAs to `/new` and `/dashboard`.
 - [x] Provide basic SEO metadata (title, description, OG).
 - [x] Ensure accessibility (landmarks, heading order, focus styles).
 - [ ] Optional: add a small "How it works" section linking to `/dashboard` and `/analyses/mock-1` when in demo mode.
@@ -40,23 +40,22 @@ tasks: []
 
 **file_list**
 
-- apps/web/src/app/landing/page.tsx (CTA to /dashboard)
-- apps/web/src/app/page.tsx (redirect to /dashboard)
+- apps/web/src/app/page.tsx (landing with CTAs to `/new` and `/dashboard`)
 - apps/web/src/app/layout.tsx (metadata/OG)
 
 **change_log**
 
-- feat(web): update landing CTA to demo
-- chore(web): add metadata and set root redirect to dashboard
+- feat(web): landing CTAs for trial and demo
+- chore(web): add metadata
 
 **completion_notes**
 
-- CTA directs to demo; metadata present; accessibility preserved; optional section deferred.
+- CTAs direct to trial and demo; metadata present; accessibility preserved; optional section deferred.
 
 **decisions**
 
 - Keep styling minimal (Tailwind utility classes) to avoid design debt.
-- Do not alter the app�?Ts default redirect unless requested (currently `/` ��' `/dashboard`).
+- Root route serves landing page directly; no redirect needed.
 
 **notes**
 
@@ -64,14 +63,14 @@ tasks: []
 
 ### dev_spec
 
-- Route: `/landing` (optionally redirect `/` to `/dashboard`).
+- Route: `/`.
 - Files: landing page, root layout metadata, favicon.
-- Content: hero value prop + CTA “Try the Demo” → `/dashboard`; optional PRD link.
+- Content: hero value prop + CTAs “Start Free 14-Day Trial” → `/new`; “Try the Demo” → `/dashboard`.
 - A11y/SEO: semantic headings, OG tags, AA contrast.
 
 ### qa_tests
 
-- Links: CTA goes to `/dashboard`, PRD link valid.
+- Links: `/new` trial link and `/dashboard` demo link work.
 - SEO: title/description/OG present; favicon loads.
 - A11y: headings/landmarks; visible focus; contrast AA.
 


### PR DESCRIPTION
## Summary
- point secondary landing CTA to `/dashboard` with "Try the Demo" copy
- document new `/new` and `/dashboard` CTAs in Story 0.2

## Testing
- `pnpm --filter web test --run`
- `pytest` *(fails: AttributeError, 422 responses, missing DB)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3355b5dc832f8ac28ad45b4738c9