### PR TITLE
feat(web): add landing page metadata

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,25 @@ import LayoutWrapper from '@/components/layout-wrapper';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <title>Blackletter Systems – The AI legal assistant built for UK compliance</title>
+        <meta
+          name="description"
+          content="Cut contract review time by 60% and never miss a GDPR obligation. Blackletter flags Article 28(3) clause gaps with explainable findings — snippet, rule ID, and rationale."
+        />
+        <meta
+          property="og:title"
+          content="Blackletter Systems – The AI legal assistant built for UK compliance"
+        />
+        <meta
+          property="og:description"
+          content="Cut contract review time by 60% and never miss a GDPR obligation. Blackletter flags Article 28(3) clause gaps with explainable findings — snippet, rule ID, and rationale."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://blackletter.systems" />
+        <meta property="og:site_name" content="Blackletter Systems" />
+        <link rel="icon" href="/favicon.ico" />
+      </head>
       <body className="min-h-screen">
         <LayoutWrapper>{children}</LayoutWrapper>
       </body>


### PR DESCRIPTION
## Summary
- add landing page title, description, and Open Graph tags
- keep lang attribute and favicon link intact

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web test`


------
https://chatgpt.com/codex/tasks/task_e_68ba33517330832f8040a82d11d27ea6