### PR TITLE
fix(ci): correct Azure workflow actions

### DIFF
--- a/.github/workflows/api-appsvc.yml
+++ b/.github/workflows/api-appsvc.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # TODO: Configure AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID in repository settings
       - uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}

--- a/.github/workflows/web-swa.yml
+++ b/.github/workflows/web-swa.yml
@@ -19,7 +19,7 @@ jobs:
       - run: pnpm --filter ./apps/web run e2e:install
       - run: pnpm --filter ./apps/web run test:e2e
       - run: pnpm --filter ./apps/web build
-      - uses: Azure/static-web-apps-deploy@v2
+      - uses: azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_SWA_TOKEN }}
           app_location: apps/web


### PR DESCRIPTION
This PR fixes the CI pipeline by:
- Correcting the version of the `azure/static-web-apps-deploy` action in `web-swa.yml` from `v2` to `v1`.
- Adding a comment to `api-appsvc.yml` to indicate that the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` variables need to be configured in the repository settings.