### PR TITLE
fix(cleanup): ensure full idempotency of cleanup script

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -56,7 +56,7 @@ done
 # Archive old tool-specific configs
 for tool in .claude .codex .cursor .crush .gemini .roomodes .qwen \
             .trae .windsurf .clinerules .kilocodemodes .qoder; do
-  if [ -d "$tool" ]; then
+  if [ -d "$tool" ] && [ ! -d "$BACKUP_DIR/$tool" ]; then
     echo "Archiving $tool/ to $BACKUP_DIR/"
     mv "$tool" "$BACKUP_DIR/"
     ignore_and_untrack "$tool"


### PR DESCRIPTION
This PR ensures the `cleanup.sh` script is fully idempotent. It now checks for the existence of tool-specific config directories in the backup location before attempting to move them, preventing errors when the script is run multiple times.