### PR TITLE
feat(web): add axe-based accessibility checks (Replaces #269)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "autoprefixer": "10.4.16",
+    "axe-core": "^4.10.3",
     "critters": "^0.0.25",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.3",

--- a/apps/web/src/components/EvidenceDrawer.tsx
+++ b/apps/web/src/components/EvidenceDrawer.tsx
@@ -64,9 +64,9 @@ export default function EvidenceDrawer({ isOpen, onClose, finding, onOpenPage }:
               )}
 
               <div className="mt-4">
-                <h4 className="text-sm font-medium">Evidence</h4>
+                <h3 className="text-sm font-medium">Evidence</h3>
                 <div
-                  className="mt-2 max-h-64 overflow-y-auto border p-2 text-sm" 
+                  className="mt-2 max-h-64 overflow-y-auto border p-2 text-sm"
                   data-testid="evidence-panel"
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{ __html: highlighted }}
@@ -75,7 +75,7 @@ export default function EvidenceDrawer({ isOpen, onClose, finding, onOpenPage }:
 
               {finding.citations && finding.citations.length > 0 && (
                 <div className="mt-4" data-testid="citations">
-                  <h4 className="text-sm font-medium">Citations</h4>
+                  <h3 className="text-sm font-medium">Citations</h3>
                   <ul className="mt-2 space-y-2">
                     {finding.citations.map((c, i) => (
                       <li key={i} className="flex items-start justify-between gap-2 text-sm" data-testid="citation-item">
@@ -109,4 +109,3 @@ export default function EvidenceDrawer({ isOpen, onClose, finding, onOpenPage }:
     </Transition>
   );
 }
-

--- a/apps/web/src/components/FindingsDrawer.tsx
+++ b/apps/web/src/components/FindingsDrawer.tsx
@@ -55,6 +55,7 @@ export default function FindingsDrawer({ open, onClose, finding }: FindingsDrawe
       <div
         ref={drawerRef}
         tabIndex={-1}
+        data-testid="findings-drawer"
         className="absolute right-0 top-0 h-full w-80 bg-white p-6 shadow-lg space-y-4"
       >
         <div>
@@ -66,10 +67,9 @@ export default function FindingsDrawer({ open, onClose, finding }: FindingsDrawe
           )}
         </div>
         <div className="flex justify-end">
-          <button onClick={onClose} className="text-sm underline">Close</button>
+          <button onClick={onClose} className="text-sm underline" data-testid="close-button">Close</button>
         </div>
       </div>
     </div>
   );
 }
-

--- a/apps/web/src/lib/anchors.test.ts
+++ b/apps/web/src/lib/anchors.test.ts
@@ -10,6 +10,7 @@ describe('highlightAnchors', () => {
     const html = highlightAnchors(sample, anchors);
     expect(html).toContain('<mark');
     expect(html).toContain('quick');
+    expect(html).toContain('style="background-color:#fef08a;color:#000"');
   });
 
   it('highlights multiple anchors', () => {
@@ -35,4 +36,3 @@ describe('highlightAnchors', () => {
     expect(html).toBe(sample);
   });
 });
-

--- a/apps/web/src/lib/anchors.ts
+++ b/apps/web/src/lib/anchors.ts
@@ -20,11 +20,10 @@ export function highlightAnchors(evidence: string, anchors: Anchor[]): string {
     if (start < lastIndex || start >= evidence.length) return; // skip overlaps/out of bounds
     result += evidence.slice(lastIndex, start);
     const segment = evidence.slice(start, end);
-    result += `<mark data-anchorkey="a${i}" tabindex="0">${segment}</mark>`;
+    result += `<mark style="background-color:#fef08a;color:#000" data-anchorkey="a${i}" tabindex="0">${segment}</mark>`;
     lastIndex = end;
   });
   result += evidence.slice(lastIndex);
 
-  return DOMPurify.sanitize(result, { ADD_ATTR: ['data-anchorkey', 'tabindex'] });
+  return DOMPurify.sanitize(result, { ADD_ATTR: ['data-anchorkey', 'tabindex', 'style'] });
 }
-

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom';
 
+// Stub canvas context for axe-core color contrast checks
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: () => ({ getImageData: () => ({ data: [] }) }),
+});
+
 // Suppress console errors during tests to avoid noise from intentional error testing
 const originalError = console.error;
 beforeAll(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       autoprefixer:
         specifier: 10.4.16
         version: 10.4.16(postcss@8.4.31)
+      axe-core:
+        specifier: ^4.10.3
+        version: 4.10.3
       critters:
         specifier: ^0.0.25
         version: 0.0.25
@@ -5750,7 +5753,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5780,7 +5783,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5795,7 +5798,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
This PR replaces #269. It manually applies the changes from the original PR to resolve significant merge conflicts that arose from unrelated histories.