### PR TITLE
fix(web): restore landing CTA variant

### DIFF
--- a/apps/web/src/content/landing.ts
+++ b/apps/web/src/content/landing.ts
@@ -12,7 +12,7 @@ export const landing = {
       {
         href: "/new",
         label: "Try the GDPR Checker",
-        variant: "secondary",
+        variant: "ghost",
       },
     ],
     micro: "Private by default. LLM is off unless you enable it. When enabled, we only send short snippets.",


### PR DESCRIPTION
## Summary
- keep secondary "Try the GDPR Checker" CTA and use `ghost` variant for compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbd3e2a518832fbf6502725b50c488